### PR TITLE
Update for Multiple Database Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pkg
 # ignore Gemfile.lock because it is rewritten by the tests
 Gemfile.lock
 
+# textmate temp files
+._*

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ case ENV["RAILS_DB"]
 when "postgres"
   gem 'pg'
 when "mysql"
-  gem 'mysql2'
+  gem 'mysql2', '~>0.2.11'
 else
   gem 'sqlite3'
 end
@@ -24,5 +24,6 @@ end
 group :test do
   gem 'redgreen'
   gem 'turn'
+  gem 'rake', '~>0.8.3'
 end
 

--- a/lib/wherex/connection.rb
+++ b/lib/wherex/connection.rb
@@ -23,7 +23,7 @@ module Wherex
       rescue NameError => e
       end
 
-      if defined? ::ActiveRecord::ConnectionAdapters::SQLiteAdapter
+      if ::ActiveRecord::Base.connection.raw_connection.respond_to? :create_function
         ::ActiveRecord::Base.connection.raw_connection.create_function( "regexp", 2 ) do |context, pattern, string|
           if string.present?
             context.result = 1 if string.match pattern


### PR DESCRIPTION
Hi Jason, 

Thanks for writing RegEx. I'm submitting a pull request to fix a bug that I encountered when using both SQLite and MySQL databases together. In my case, I had a database config file that looked like: 

```
development:
  adapter: mysql2
  database: mysql_dev

development_sqlite:
  adapter: sqlite3
  database: db/development.sqlite3
```

Typically I was using the mysql database, but in a few handful of models I was importing data from a temporary sqlite database, including the line   establish_connection :development_sqlite inside the relevant models, like:

```
class ImportStudent < ActiveRecord::Base
  establish_connection :development_sqlite
end
```

When I did this, ::ActiveRecord::ConnectionAdapters::SQLiteAdapter would be defined, even though it wasn't actually the active, checked out adapter, and I would get the following error on the first use of the model: 

```
NoMethodError: undefined method `create_function' for #<Mysql2::Client:0x1015058a0>

from /usr/local/lib/ruby/gems/1.8/gems/wherex-1.0.0/lib/wherex/connection.rb:27:in `establish_connection'
from /usr/local/lib/ruby/gems/1.8/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/connection_specification.rb:80:in `establish_connection_without_wherex'
from /usr/local/lib/ruby/gems/1.8/gems/wherex-1.0.0/lib/wherex/connection.rb:12:in `establish_connection'
from /usr/local/lib/ruby/gems/1.8/gems/activerecord-3.0.9/lib/active_record/connection_adapters/abstract/connection_specification.rb:60:in `establish_connection_without_wherex'
from /usr/local/lib/ruby/gems/1.8/gems/wherex-1.0.0/lib/wherex/connection.rb:12:in `establish_connection'
from /Data/home/erik/code/panda_shared/app/models/import_student.rb:4
```

My fix checks if the connection responds to :create_function, instead of checking it's specific identity as a SQLite Adapter.  I'm not sure if this is the best way to do it, since it opens the possibility of another adapter supporting create_function with a different signature, etc, but it seems like a decent solution to me.

I'm sorry, but I couldn't figure out a way to test this setup, since your helper only tests one adapter at a time. At the very least, it doesn't break any existing tests. Since I'm not submitting a test, I'd be fine if you just ignored this request; I'd understand. But I thought I'd send it anyway.

Thanks,

Erik 

(PS - I also locked down the Gemfile for compatible Rake and Mysql2 gem versions in a separate commit, since both have newer, incompatible versions).
